### PR TITLE
Fixing conflict with getRoles()

### DIFF
--- a/Model/Role.php
+++ b/Model/Role.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Dayspring\LoginBundle\Model;
-
-use Dayspring\LoginBundle\Model\om\BaseRole;
-
-class Role extends BaseRole
-{
-}

--- a/Model/RolePeer.php
+++ b/Model/RolePeer.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Dayspring\LoginBundle\Model;
-
-use Dayspring\LoginBundle\Model\om\BaseRolePeer;
-
-class RolePeer extends BaseRolePeer
-{
-}

--- a/Model/RoleQuery.php
+++ b/Model/RoleQuery.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Dayspring\LoginBundle\Model;
-
-use Dayspring\LoginBundle\Model\om\BaseRoleQuery;
-
-class RoleQuery extends BaseRoleQuery
-{
-}

--- a/Model/SecurityRole.php
+++ b/Model/SecurityRole.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Dayspring\LoginBundle\Model;
+
+use Dayspring\LoginBundle\Model\om\BaseSecurityRole;
+
+class SecurityRole extends BaseSecurityRole
+{
+}

--- a/Model/SecurityRolePeer.php
+++ b/Model/SecurityRolePeer.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Dayspring\LoginBundle\Model;
+
+use Dayspring\LoginBundle\Model\om\BaseSecurityRolePeer;
+
+class SecurityRolePeer extends BaseSecurityRolePeer
+{
+}

--- a/Model/SecurityRoleQuery.php
+++ b/Model/SecurityRoleQuery.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Dayspring\LoginBundle\Model;
+
+use Dayspring\LoginBundle\Model\om\BaseSecurityRoleQuery;
+
+class SecurityRoleQuery extends BaseSecurityRoleQuery
+{
+}

--- a/Model/User.php
+++ b/Model/User.php
@@ -30,7 +30,7 @@ class User extends BaseUser implements UserInterface
 
     public function getRoles($criteria = null, PropelPDO $con = null)
     {
-        $dbRoles = parent::getRoles($criteria, $con);
+        $dbRoles = parent::getSecurityRoles($criteria, $con);
 
         $roles = [];
         foreach ($dbRoles as $r) {

--- a/Resources/config/user_schema.xml
+++ b/Resources/config/user_schema.xml
@@ -19,7 +19,7 @@
             <parameter name="Engine" value="InnoDB"/>
         </vendor>
     </table>
-    <table name="roles" phpName="Role" idMethod="native">
+    <table name="roles" phpName="SecurityRole" idMethod="native">
         <column name="id" phpName="Id" type="INTEGER" primaryKey="true" autoIncrement="true" required="true"/>
         <column name="role_name" phpName="RoleName" type="VARCHAR" size="50" required="true"/>
         <vendor type="mysql">

--- a/Tests/Controller/UserAccountControllerTest.php
+++ b/Tests/Controller/UserAccountControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 namespace Dayspring\LoginBundle\Tests\Controller;
 
-use Dayspring\LoginBundle\Model\RoleQuery;
+use Dayspring\LoginBundle\Model\SecurityRoleQuery;
 use Dayspring\LoginBundle\Model\RoleUserQuery;
 use Dayspring\LoginBundle\Model\User;
 use Dayspring\LoginBundle\Model\UserQuery;
@@ -33,7 +33,7 @@ class UserAccountControllerTest extends WebTestCase
         $user->setEmail(sprintf("test+%s@test.com", microtime()));
         $encoded = $encoder->encodePassword($user, 'password');
         $user->setPassword($encoded);
-        $user->addRole(RoleQuery::create()->filterByRoleName("ROLE_User")->findOneOrCreate());
+        $user->addSecurityRole(SecurityRoleQuery::create()->filterByRoleName("ROLE_User")->findOneOrCreate());
         $user->save();
 
         $crawler = $this->client->request("GET", "/login");
@@ -64,7 +64,7 @@ class UserAccountControllerTest extends WebTestCase
         $user->setEmail(sprintf("test+%s@test.com", microtime()));
         $encoded = $encoder->encodePassword($user, 'password');
         $user->setPassword($encoded);
-        $user->addRole(RoleQuery::create()->filterByRoleName("ROLE_User")->findOneOrCreate());
+        $user->addSecurityRole(SecurityRoleQuery::create()->filterByRoleName("ROLE_User")->findOneOrCreate());
         $user->save();
 
         $this->assertNull($user->getLastLoginDate());

--- a/Tests/Model/UserTest.php
+++ b/Tests/Model/UserTest.php
@@ -8,7 +8,7 @@
 
 namespace Dayspring\LoginBundle\Tests\Model;
 
-use Dayspring\LoginBundle\Model\Role;
+use Dayspring\LoginBundle\Model\SecurityRole;
 use Dayspring\LoginBundle\Model\User;
 use Dayspring\LoginBundle\Tests\WebTestCase;
 
@@ -35,9 +35,9 @@ class UserTest extends WebTestCase
         $user = new User();
         $user->setEmail('helloworld');
 
-        $r = new Role();
+        $r = new SecurityRole();
         $r->setRoleName("ROLE_TEST");
-        $user->addRole($r);
+        $user->addSecurityRole($r);
 
         $this->assertEquals(1, count($user->getRoles()));
         $this->assertEquals(array("ROLE_TEST"), $user->getRoles());


### PR DESCRIPTION
Symfony assumes the user object will have a getRoles() method that returns an array of strings. This hid the getRole() method of BaseUser that returned the Propel object Role.

Fixed by renaming the Propel object to SecurityRole.
