### PR TITLE
switch to dayspring-tech/propel-bundle

### DIFF
--- a/.github/workflows/symfony.yml
+++ b/.github/workflows/symfony.yml
@@ -22,7 +22,7 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: sqlite3, zip
           coverage: xdebug
-          tools: composer:v1
+          tools: composer:v2
 
       - name: Get Composer Cache Directory
         id: composer-cache

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "sensio/framework-extra-bundle": "^5.0.1",
         "symfony/yaml": "^3.4.31|^4.0",
         "phing/phing": "^2.16",
-        "propel/propel-bundle": "1.7.x-dev",
+        "dayspring-tech/propel-bundle": "^1.7.0",
         "symfony/swiftmailer-bundle": "3.3.*",
         "symfony/symfony": "^3.4.31|^4.0",
         "symfony/phpunit-bridge": "^3.4.31|^4.0",
@@ -52,12 +52,6 @@
             "Tests/"
         ]
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url":  "git@github.com:dayspring-tech/PropelBundle.git"
-        }
-    ],
     "scripts": {
         "ci-test": [
             "Composer\\Config::disableProcessTimeout",


### PR DESCRIPTION
Instead of using `vcs` block and `1.7.x-dev` version, use `dayspring-tech` fork of `propel-bundle` 